### PR TITLE
Use default credential provider chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.class
 target/
 dependency-reduced-pom.xml
+.idea
+*.iml
+.vagrant

--- a/README.md
+++ b/README.md
@@ -14,15 +14,27 @@ cp target/flume-kinesis-{version}.jar FLUME_HOME_DIR/plugins.d/flume-kinesis/lib
 
 ## Configuration
 
-Check the examples under `conf/` for specific examples.  All values without defaults are required.
+Check the examples under `conf/` for specific examples.
+
+### AWS Credentials
+
+The source and sink will attempt to use a [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html#DefaultAWSCredentialsProviderChain)
+if possible to configure AWS credentials.  These can be specified as one of:
+
+* Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+* Java System Properties - aws.accessKeyId and aws.secretKey
+* Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI
+* Instance profile credentials delivered through the Amazon EC2 metadata service
+
+For backward compatibility you can also specify credentials in the source/sink configuration by setting `accessKeyId` and `secretAccessKey`.
 
 ### Kinesis Source Options
 
 |Name|Default|Description|
 -------|-----------|-------------|
 |endpoint|https://kinesis.us-east-1.amazonaws.com|endpoint to access kinesis|
-|accessKeyId|null|AWS Access Key ID|
-|secretAccessKey|null|AWS Secret Access Key|
+|accessKeyId|null|AWS Access Key ID, deprecated - see AWS Credentials above|
+|secretAccessKey|null|AWS Secret Access Key, deprecated - see AWS Credentials above|
 |streamName|null|name of Kinesis stream|
 |applicationName|null|name of Kinesis application|
 |initialPosition|TRIM_HORIZON|strategy to set the initial iterator position|
@@ -46,10 +58,9 @@ Options for both are as follows:
 |Name|Default|Description|
 -------|-----------|-------------|
 |endpoint|https://kinesis.us-east-1.amazonaws.com|endpoint to access kinesis|
-|accessKeyId|null|AWS Access Key ID|
-|secretAccessKey|null|AWS Secret Access Key|
+|accessKeyId|null|AWS Access Key ID, deprecated - see AWS Credentials above|
+|secretAccessKey|null|AWS Secret Access Key, deprecated - see AWS Credentials above|
 |streamName|null|name of Kinesis/Firehose stream|
-|numberOfPartitions|1|number of Kinesis partitions.  Set this much higher than actual number of shards to get better uniforimity when sinking across shards.|
 |batchSize|100|max number of events to send per API call to Kinesis.  Must be between 1 and 500.|
 |maxAttempts|100|max number of times to attempt to send events.  After this the batch will be considered failed.  Must be >= 1.|
 |rollbackAfterMaxAttempts|false|whether to roll back the flume transaction if events cannot be sent after max attempts|

--- a/conf/kinesis_to_kinesis
+++ b/conf/kinesis_to_kinesis
@@ -4,8 +4,6 @@ node1.channels = diskchannel
 
 ## Source
 node1.sources.KinesisSource.type = com.amazonaws.services.kinesis.flume.KinesisSource
-node1.sources.KinesisSource.accessKeyId =
-node1.sources.KinesisSource.secretAccessKey =
 node1.sources.KinesisSource.applicationName = FlumeSource
 node1.sources.KinesisSource.streamName = myLargeStream
 node1.sources.KinesisSource.initialPosition = TRIM_HORIZON
@@ -13,10 +11,7 @@ node1.sources.KinesisSource.endpoint = https://kinesis.us-east-1.amazonaws.com
 
 ## Sink
 node1.sinks.KinesisSink.type = com.amazonaws.services.kinesis.flume.KinesisSink 
-node1.sinks.KinesisSink.accessKeyId =
-node1.sinks.KinesisSink.secretAccessKey =
-node1.sinks.KinesisSink.numberOfPartitions = 2
-node1.sinks.KinesisSink.streamName = mySecondLargeStream 
+node1.sinks.KinesisSink.streamName = mySecondLargeStream
 node1.sinks.KinesisSink.endpoint = https://kinesis.us-east-1.amazonaws.com
 
 #i# Use a channel which buffers events in memory

--- a/conf/kinesis_to_many
+++ b/conf/kinesis_to_many
@@ -4,8 +4,6 @@ node1.channels = diskchannel
 
 ## Source
 node1.sources.KinesisSource.type = com.amazonaws.services.kinesis.flume.KinesisSource
-node1.sources.KinesisSource.accessKeyId =
-node1.sources.KinesisSource.secretAccessKey =
 node1.sources.KinesisSource.applicationName = FlumeSource
 node1.sources.KinesisSource.streamName = myLargeStream
 node1.sources.KinesisSource.initialPosition = LATEST
@@ -13,10 +11,7 @@ node1.sources.KinesisSource.endpoint = https://kinesis.us-east-1.amazonaws.com
 
 ## Sink1
 node1.sinks.KinesisSink.type = com.amazonaws.services.kinesis.flume.KinesisSink 
-node1.sinks.KinesisSink.accessKeyId =
-node1.sinks.KinesisSink.secretAccessKey =
-node1.sinks.KinesisSink.numberOfPartitions = 2
-node1.sinks.KinesisSink.streamName = mySecondLargeStream 
+node1.sinks.KinesisSink.streamName = mySecondLargeStream
 node1.sinks.KinesisSink.endpoint = https://kinesis.us-east-1.amazonaws.com
 
 ## Sink2

--- a/conf/kinesis_to_s3
+++ b/conf/kinesis_to_s3
@@ -4,8 +4,6 @@ node1.channels = diskchannel
 
 ## Source
 node1.sources.KinesisSource.type = com.amazonaws.services.kinesis.flume.KinesisSource
-node1.sources.KinesisSource.accessKeyId =
-node1.sources.KinesisSource.secretAccessKey =
 node1.sources.KinesisSource.applicationName = FlumeSource
 node1.sources.KinesisSource.streamName = myLargeStream
 node1.sources.KinesisSource.initialPosition = TRIM_HORIZON

--- a/conf/kinesis_to_s3_waggregation
+++ b/conf/kinesis_to_s3_waggregation
@@ -4,8 +4,6 @@ node1.channels = diskchannel
 
 ## Source
 node1.sources.KinesisSource.type = com.amazonaws.services.kinesis.flume.KinesisSource
-node1.sources.KinesisSource.accessKeyId =
-node1.sources.KinesisSource.secretAccessKey =
 node1.sources.KinesisSource.applicationName = FlumeSource
 node1.sources.KinesisSource.streamName = myLargeStream
 node1.sources.KinesisSource.initialPosition = TRIM_HORIZON

--- a/conf/producer_to_kinesis
+++ b/conf/producer_to_kinesis
@@ -9,9 +9,6 @@ node1.sources.netcat.port = 44444
 
 ## Sink
 node1.sinks.KinesisSink.type = com.amazonaws.services.kinesis.flume.KinesisSink
-node1.sinks.KinesisSink.accessKeyId =
-node1.sinks.KinesisSink.secretAccessKey =
-node1.sinks.KinesisSink.numberOfPartitions = 2
 node1.sinks.KinesisSink.streamName = mySecondLargeStream
 node1.sinks.KinesisSink.endpoint = https://kinesis.us-east-1.amazonaws.com
 

--- a/conf/producer_to_kinesis_firehose
+++ b/conf/producer_to_kinesis_firehose
@@ -9,10 +9,7 @@ node1.sources.netcat.port = 44444
 
 ## Sink
 node1.sinks.KinesisSink.type = com.amazonaws.services.kinesis.flume.FirehoseSink 
-node1.sinks.KinesisSink.accessKeyId =
-node1.sinks.KinesisSink.secretAccessKey =
-node1.sinks.KinesisSink.numberOfPartitions = 2
-node1.sinks.KinesisSink.streamName = mySecondLargeStream 
+node1.sinks.KinesisSink.streamName = mySecondLargeStream
 node1.sinks.KinesisSink.endpoint = https://firehose.us-east-1.amazonaws.com
 
 #i# Use a channel which buffers events in memory

--- a/src/main/java/com/amazonaws/services/kinesis/FlumeSourceRecordProcessor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/FlumeSourceRecordProcessor.java
@@ -36,7 +36,7 @@ import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorC
 import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownReason;
 import com.amazonaws.services.kinesis.model.Record;
 
-public class FlumeSourceRecordProcessor implements IRecordProcessor {
+class FlumeSourceRecordProcessor implements IRecordProcessor {
   private static final Log LOG = LogFactory.getLog(FlumeSourceRecordProcessor.class);
   private String kinesisShardId;
 
@@ -50,8 +50,8 @@ public class FlumeSourceRecordProcessor implements IRecordProcessor {
     
   private final CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder();
     
-  ChannelProcessor chProcessor;
-  public FlumeSourceRecordProcessor(ChannelProcessor chProcessor) {
+  private ChannelProcessor chProcessor;
+  FlumeSourceRecordProcessor(ChannelProcessor chProcessor) {
     super();
     this.chProcessor = chProcessor;
   }
@@ -76,14 +76,14 @@ public class FlumeSourceRecordProcessor implements IRecordProcessor {
   }
 
   /** Process records performing retries as needed. Skip "poison pill" records.
-   * @param records
+   * @param records list of records to process
    */
   private void processRecordsWithRetries(List<Record> records) {
     
     Event event;
     Map<String, String> headers;
  
-    ArrayList<Event> eventList=new ArrayList<Event>();
+    ArrayList<Event> eventList=new ArrayList<>();
         
     for (Record record : records) {
       boolean processedSuccessfully = false;
@@ -91,7 +91,7 @@ public class FlumeSourceRecordProcessor implements IRecordProcessor {
       for (int i = 0; i < NUM_RETRIES; i++) {
         try {
           event = new SimpleEvent();
-          headers = new HashMap<String, String>();
+          headers = new HashMap<>();
           headers.put("timestamp", String.valueOf(System.currentTimeMillis()));
           String data = decoder.decode(record.getData()).toString();
           LOG.info(record.getSequenceNumber() + ", " + record.getPartitionKey()+":"+data);
@@ -136,7 +136,7 @@ public class FlumeSourceRecordProcessor implements IRecordProcessor {
   }
 
   /** Checkpoint with retries.
-   * @param checkpointer
+   * @param checkpointer user implementation to handle checkpointing location in stream
    */
   private void checkpoint(IRecordProcessorCheckpointer checkpointer) {
     LOG.info("Checkpointing shard " + kinesisShardId);

--- a/src/main/java/com/amazonaws/services/kinesis/MyAwsCredential.java
+++ b/src/main/java/com/amazonaws/services/kinesis/MyAwsCredential.java
@@ -20,8 +20,8 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 
 public class MyAwsCredential implements AWSCredentialsProvider{
-  String accessKey;
-  String accessSecretKey;
+  private String accessKey;
+  private String accessSecretKey;
 
   public MyAwsCredential(String accessKey,String accessSecretKey){
     this.accessKey = accessKey;

--- a/src/main/java/com/amazonaws/services/kinesis/MyAwsCredentials.java
+++ b/src/main/java/com/amazonaws/services/kinesis/MyAwsCredentials.java
@@ -19,18 +19,18 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 
-public class MyAwsCredential implements AWSCredentialsProvider{
+public class MyAwsCredentials implements AWSCredentialsProvider {
   private String accessKey;
   private String accessSecretKey;
 
-  public MyAwsCredential(String accessKey,String accessSecretKey){
+  public MyAwsCredentials(String accessKey, String accessSecretKey) {
     this.accessKey = accessKey;
     this.accessSecretKey = accessSecretKey;
   }
 
   @Override
-  public AWSCredentials getCredentials(){
-    return new BasicAWSCredentials(this.accessKey,this.accessSecretKey);
+  public AWSCredentials getCredentials() {
+    return new BasicAWSCredentials(this.accessKey, this.accessSecretKey);
   }
 
   @Override

--- a/src/main/java/com/amazonaws/services/kinesis/RecordProcessorFactory.java
+++ b/src/main/java/com/amazonaws/services/kinesis/RecordProcessorFactory.java
@@ -20,7 +20,7 @@ import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor;
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory;
 
 public class RecordProcessorFactory implements IRecordProcessorFactory {
-  ChannelProcessor chProcessor;
+  private ChannelProcessor chProcessor;
 
   public RecordProcessorFactory(ChannelProcessor channelProcessor) {
     super();

--- a/src/main/java/com/amazonaws/services/kinesis/flume/ConfigurationConstants.java
+++ b/src/main/java/com/amazonaws/services/kinesis/flume/ConfigurationConstants.java
@@ -3,22 +3,20 @@ package com.amazonaws.services.kinesis.flume;
 /**
  * Contains configuration constants used by Kinesis and Firehose sources/sinks
  */
-public final class ConfigurationConstants {
-  public static final int DEFAULT_PARTITION_SIZE = 1;
+final class ConfigurationConstants {
+  static final int DEFAULT_BATCH_SIZE = 100;
 
-  public static final int DEFAULT_BATCH_SIZE = 100;
+  static final int DEFAULT_MAX_ATTEMPTS = 100;
 
-  public static final int DEFAULT_MAX_ATTEMPTS = 100;
+  static final boolean DEFAULT_ROLLBACK_AFTER_MAX_ATTEMPTS = false;
 
-  public static final boolean DEFAULT_ROLLBACK_AFTER_MAX_ATTEMPTS = false;
+  static final long BACKOFF_TIME_IN_MILLIS = 100L;
 
-  public static final long BACKOFF_TIME_IN_MILLIS = 100L;
+  static final boolean DEFAULT_PARTITION_KEY_FROM_EVENT = false;
 
-  public static final boolean DEFAULT_PARTITION_KEY_FROM_EVENT = false;
+  static final String DEFAULT_KINESIS_ENDPOINT = "https://kinesis.us-east-1.amazonaws.com";
 
-  public static final String DEFAULT_KINESIS_ENDPOINT = "https://kinesis.us-east-1.amazonaws.com";
-
-  public static final String DEFAULT_FIREHOSE_ENDPOINT = "https://firehose.us-east-1.amazonaws.com";
+  static final String DEFAULT_FIREHOSE_ENDPOINT = "https://firehose.us-east-1.amazonaws.com";
 
   private ConfigurationConstants() {
     // Disable object creation

--- a/src/main/java/com/amazonaws/services/kinesis/flume/KinesisSink.java
+++ b/src/main/java/com/amazonaws/services/kinesis/flume/KinesisSink.java
@@ -21,6 +21,9 @@ import java.util.Random;
 import java.util.List;
 import java.util.ArrayList;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.kinesis.MyAwsCredentials;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -35,7 +38,6 @@ import org.apache.flume.conf.Configurable;
 import org.apache.flume.sink.AbstractSink;
 import org.apache.flume.instrumentation.SinkCounter;
 
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.kinesis.AmazonKinesisClient;
 import com.amazonaws.services.kinesis.model.PutRecordsRequest;
 import com.amazonaws.services.kinesis.model.PutRecordsRequestEntry;
@@ -49,35 +51,37 @@ public class KinesisSink extends AbstractSink implements Configurable {
   private SinkCounter sinkCounter;
 
   private static AmazonKinesisClient kinesisClient;
-  private String accessKeyId;
-  private String secretAccessKey;
   private String streamName;
   private String endpoint;
   private int batchSize;
   private int maxAttempts;
   private boolean rollbackAfterMaxAttempts;
   private boolean partitionKeyFromEvent;
+  private AWSCredentialsProvider credentialsProvider;
 
   @Override
   public void configure(Context context) {
     this.endpoint = context.getString("endpoint", ConfigurationConstants.DEFAULT_KINESIS_ENDPOINT);
 
-    this.accessKeyId = Preconditions.checkNotNull(
-        context.getString("accessKeyId"), "accessKeyId is required");
+    String accessKeyId = context.getString("accessKeyId");
 
-    this.secretAccessKey = Preconditions.checkNotNull(
-        context.getString("secretAccessKey"), "secretAccessKey is required");
+    String secretAccessKey = context.getString("secretAccessKey");
+
+    if (accessKeyId != null && secretAccessKey != null) {
+      credentialsProvider = new MyAwsCredentials(accessKeyId, secretAccessKey);
+    } else {
+      credentialsProvider = new DefaultAWSCredentialsProviderChain();
+    }
 
     this.streamName = Preconditions.checkNotNull(
-        context.getString("streamName"), "streamName is required");
+      context.getString("streamName"), "streamName is required");
 
     this.batchSize = context.getInteger("batchSize", ConfigurationConstants.DEFAULT_BATCH_SIZE);
     Preconditions.checkArgument(batchSize > 0 && batchSize <= 500,
-        "batchSize must be between 1 and 500");
+      "batchSize must be between 1 and 500");
 
     this.maxAttempts = context.getInteger("maxAttempts", ConfigurationConstants.DEFAULT_MAX_ATTEMPTS);
-    Preconditions.checkArgument(maxAttempts > 0,
-        "maxAttempts must be greater than 0");
+    Preconditions.checkArgument(maxAttempts > 0, "maxAttempts must be greater than 0");
 
     this.rollbackAfterMaxAttempts = context.getBoolean("rollbackAfterMaxAttempts", ConfigurationConstants.DEFAULT_ROLLBACK_AFTER_MAX_ATTEMPTS);
 
@@ -92,13 +96,13 @@ public class KinesisSink extends AbstractSink implements Configurable {
 
   @Override
   public void start() {
-    kinesisClient = new AmazonKinesisClient(new BasicAWSCredentials(this.accessKeyId,this.secretAccessKey));
+    kinesisClient = new AmazonKinesisClient(credentialsProvider);
     kinesisClient.setEndpoint(this.endpoint);
     sinkCounter.start();
   }
 
   @Override
-  public void stop () {
+  public void stop() {
     sinkCounter.stop();
   }
 
@@ -178,7 +182,7 @@ public class KinesisSink extends AbstractSink implements Configurable {
       }
     } catch (Throwable t) {
       txn.rollback();
-      LOG.error("Failed to commit transaction. Transaction rolled back. ", t);
+      LOG.error("Failed to commit transaction. Transaction rolled back.", t);
       status = Status.BACKOFF;
       if (t instanceof Error) {
         throw (Error)t;


### PR DESCRIPTION
Allow for using the [DefaultAWSCredentialProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html#DefaultAWSCredentialsProviderChain) in place of requiring hardcoded access keys in the flume config.  This will allow using EC2 Instance Profiles and other methods to access Kinesis so users can avoid putting sensitive keys in plain text.

The existing hardcoded credentials are still supported for now to allow for backward compatibility.  If those are present in the config they take precedence over the default chain.